### PR TITLE
fix: switch to pt-shared-prod-small runners [ESUSDLC-4136]

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: pt-shared-prod-small
     steps:
       - name: Create Release
-        uses: Paymentology/release-actions/create-semantic-release@v1.5.0-create-hotfix-branch
+        uses: Paymentology/release-actions/create-semantic-release@v1.4.3-create-semantic-release
         with:
           app-id: ${{ vars.CODE_RELEASE_APP_ID }}
           private-key: ${{ secrets.CODE_RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -10,10 +10,10 @@ permissions:
 
 jobs:
   create_release:
-    runs-on: ubuntu-24.04
+    runs-on: pt-shared-prod-small
     steps:
       - name: Create Release
-        uses: Paymentology/release-actions/create-semantic-release@v1.3.1
+        uses: Paymentology/release-actions/create-semantic-release@v1.5.0-create-hotfix-branch
         with:
           app-id: ${{ vars.CODE_RELEASE_APP_ID }}
           private-key: ${{ secrets.CODE_RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Automated update for ESUSDLC-4136: switch semantic-release workflow to `pt-shared-prod-small` and standardize Create Release action version.